### PR TITLE
Add draft release cli tool

### DIFF
--- a/src/draft.js
+++ b/src/draft.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+import * as fs from "fs";
+
+import Octokit from "@octokit/rest";
+import { extractFromGithubUrl } from "./helpers/github";
+import { commandLineSetUpPublish } from "./helpers/cli";
+
+async function publishDraftRelease() {
+  const { owner, repo } = repoInfo;
+
+  console.log(
+    `Creating draft release ${nextVersion} (${commit}) to ${owner}/${repo}`
+  );
+
+  const result = await octokit.repos.createRelease({
+    owner,
+    repo,
+    tag_name: nextVersion,
+    target_commitish: commit,
+    name: nextVersion,
+    body: content,
+    draft: true,
+    prerelease: false
+  });
+  if (result.status === 201) {
+    console.log(`Draft release created (${result.data.html_url})`);
+  } else {
+    console.log("Draft release failed", result.status);
+  }
+  return result;
+}
+
+async function main() {
+  await publishDraftRelease();
+}
+
+/* main*/
+
+const { repo, nextVersion, commit, file, token } = commandLineSetUpPublish();
+
+const repoInfo = extractFromGithubUrl(repo);
+const octokit = new Octokit();
+const content = fs.readFileSync(file, "utf8");
+
+octokit.authenticate({
+  type: "token",
+  token
+});
+
+main();

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -2,7 +2,7 @@ import yargs from "yargs";
 
 export const setUpCli = () =>
   yargs
-    .command("generate", "Generate release notes", commandLineSetUp)
+    .command(["generate", "$0"], "Generate release notes", commandLineSetUp)
     .command("draft", "Create draft release on Github", commandLineSetUpPublish)
     .demandCommand().argv;
 

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -1,7 +1,13 @@
 import yargs from "yargs";
 
-export const commandLineSetUp = () =>
+export const setUpCli = () =>
   yargs
+    .command("generate", "Generate release notes", commandLineSetUp)
+    .command("draft", "Create draft release on Github", commandLineSetUpPublish)
+    .demandCommand().argv;
+
+const commandLineSetUp = y =>
+  y
     .env("GITHUB")
     .option("token", {
       describe: "GITHUB_TOKEN env should be set",
@@ -35,10 +41,10 @@ export const commandLineSetUp = () =>
       }
     })
     .help()
-    .alias("h", "help").argv;
+    .alias("h", "help");
 
-export const commandLineSetUpPublish = () =>
-  yargs
+const commandLineSetUpPublish = y =>
+  y
     .env("GITHUB_TOKEN")
     .option("token", {
       describe: "GITHUB_TOKEN env should be set",
@@ -67,4 +73,4 @@ export const commandLineSetUpPublish = () =>
       }
     })
     .help()
-    .alias("h", "help").argv;
+    .alias("h", "help");

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -36,3 +36,35 @@ export const commandLineSetUp = () =>
     })
     .help()
     .alias("h", "help").argv;
+
+export const commandLineSetUpPublish = () =>
+  yargs
+    .env("GITHUB_TOKEN")
+    .option("token", {
+      describe: "GITHUB_TOKEN env should be set",
+      demandOption: true
+    })
+    .options({
+      repo: {
+        alias: "r",
+        describe: "Github repo to push draft release to",
+        demandOption: true
+      },
+      "next-version": {
+        alias: "nv",
+        describe: "The next version of the software to be release",
+        demandOption: true
+      },
+      commit: {
+        alias: "c",
+        describe: "The commit that will be tagged",
+        demandOption: true
+      },
+      file: {
+        describe:
+          "File from which to read that will be used for the release description",
+        demandOption: true
+      }
+    })
+    .help()
+    .alias("h", "help").argv;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import { setUpCli } from "./helpers/cli";
+
+setUpCli();


### PR DESCRIPTION
- Introduces a new tool (`practicle draft ...args`) that allows a user to create a draft release on github
- Refactor cli to allow subcommands

Args:
<img width="565" alt="screen shot 2018-08-24 at 17 42 33" src="https://user-images.githubusercontent.com/849508/44596702-20790c80-a7c5-11e8-9613-efcbee23946a.png">
