### PR TITLE
Extract log message from pr body if 'changelog:' pattern exists

### DIFF
--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env ./node_modules/.bin/babel-node
 import Octokit from "@octokit/rest";
 import semverSort from "semver-sort";
-import { extractChangeLog, buildOutput } from "./helpers/changelog";
+import { extractChangeLogMessage, buildOutput } from "./helpers/changelog";
 import { extractFromGithubUrl } from "./helpers/github";
 import { versionFilter } from "./helpers/utils";
 
@@ -67,7 +67,7 @@ async function getAllPullRequests(repoInfo) {
 
   return results
     .map(pr => {
-      const changelogMessage = extractChangeLog(pr);
+      const changelogMessage = extractChangeLogMessage(pr);
       const { url, merge_commit_sha, number } = pr;
       if (changelogMessage) {
         return {

--- a/src/helpers/changelog.js
+++ b/src/helpers/changelog.js
@@ -1,9 +1,21 @@
-export const extractChangeLog = obj => {
+export const extractChangeLogMessage = obj => {
   const label = obj.labels.filter(l => {
     return l.name === "changelog";
   });
 
-  return label.length > 0 ? obj.title : null;
+  const changelogRegex = /(^|\n|\r)changelog\:(.*)/;
+
+  const getMessage = obj => {
+    const regexMatch = obj.body && obj.body.match(changelogRegex);
+    return regexMatch &&
+      regexMatch.length >= 2 &&
+      regexMatch[2] &&
+      regexMatch[2] !== ""
+      ? regexMatch[2].trim()
+      : obj.title;
+  };
+
+  return label.length > 0 ? getMessage(obj) : null;
 };
 
 export const buildOutput = (logs, header, repoInfo, outputPrLinks) => {
@@ -11,7 +23,6 @@ export const buildOutput = (logs, header, repoInfo, outputPrLinks) => {
     `;
 
   logs.forEach(_ => {
-    debugger;
     out += outputPrLinks
       ? `\n- ${_.message} [\#${_.number}](https://github.com/${
           repoInfo.owner

--- a/src/helpers/changelog.test.js
+++ b/src/helpers/changelog.test.js
@@ -1,0 +1,62 @@
+import { buildOutput, extractChangeLogMessage } from "./changelog";
+
+jest.spyOn(global.console, "log").mockImplementation(() => {});
+
+const getLog = () => console.log.mock.calls[0][0];
+
+describe("extractChangeLogMessage", () => {
+  test("maps title value by default", () => {
+    const title = "emily";
+    const pr = {
+      labels: [{ name: "changelog" }],
+      title
+    };
+    const actual = extractChangeLogMessage(pr);
+    expect(actual).toEqual(title);
+  });
+  test("maps `message:` when at the beginning of a line", () => {
+    const title = "emily";
+    const changeLogMessage = "elliot";
+
+    const pr = {
+      labels: [{ name: "changelog" }],
+      title,
+      body: `changelog: ${changeLogMessage}`
+    };
+    const actual = extractChangeLogMessage(pr);
+    expect(actual).toEqual("elliot");
+  });
+  test("does not map `message:` when not at the beginning of a line", () => {
+    const title = "emily";
+    const changeLogMessage = "elliot";
+
+    const pr = {
+      labels: [{ name: "changelog" }],
+      title,
+      body: `foo changelog: ${changeLogMessage}`
+    };
+    const actual = extractChangeLogMessage(pr);
+    expect(actual).toEqual(title);
+  });
+});
+
+describe("changelog output", () => {
+  test("prints out change log", () => {
+    const message = "foobar";
+    const logs = [{ message }];
+    const header = "foobar";
+    buildOutput(logs, header, { owner: "owner", repo: "repo" }, false);
+
+    expect(getLog()).toEqual(expect.stringContaining(header));
+    expect(getLog()).toEqual(expect.stringContaining(message));
+  });
+  test("prints out change log", () => {
+    const message = "foobar";
+    const logs = [{ message }];
+    const header = "foobar";
+    buildOutput(logs, header, { owner: "owner", repo: "repo" }, false);
+
+    expect(getLog()).toEqual(expect.stringContaining(header));
+    expect(getLog()).toEqual(expect.stringContaining(message));
+  });
+});

--- a/src/helpers/changelog.test.js
+++ b/src/helpers/changelog.test.js
@@ -14,7 +14,7 @@ describe("extractChangeLogMessage", () => {
     const actual = extractChangeLogMessage(pr);
     expect(actual).toEqual(title);
   });
-  test("maps `message:` when at the beginning of a line", () => {
+  test("maps `changelog:` when at the beginning of a line", () => {
     const title = "emily";
     const changeLogMessage = "elliot";
 
@@ -26,7 +26,7 @@ describe("extractChangeLogMessage", () => {
     const actual = extractChangeLogMessage(pr);
     expect(actual).toEqual("elliot");
   });
-  test("does not map `message:` when not at the beginning of a line", () => {
+  test("does not map `changelog:` when not at the beginning of a line", () => {
     const title = "emily";
     const changeLogMessage = "elliot";
 
@@ -37,6 +37,18 @@ describe("extractChangeLogMessage", () => {
     };
     const actual = extractChangeLogMessage(pr);
     expect(actual).toEqual(title);
+  });
+  test("does not map more than one line on `changelog:`", () => {
+    const title = "emily";
+    const changeLogMessage = "elliot";
+
+    const pr = {
+      labels: [{ name: "changelog" }],
+      title,
+      body: "foo\nchangelog: " + changeLogMessage + "\nyo!"
+    };
+    const actual = extractChangeLogMessage(pr);
+    expect(actual).toEqual(changeLogMessage);
   });
 });
 


### PR DESCRIPTION
This pr allows a log message to be embedded in to the pr body.

Usage: Add `changelog:` to pr body and the text after the pattern will used as the log message
