### PR TITLE
Add subcommand for publish release directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,20 @@ Options:
 ```
 
 ## `draft-release`
-Takes contents from a file and creates a draft release on GitHub using that contents.
+Takes contents from a file and creates a _draft_ release on GitHub using that contents.
+
+```bash
+Options:
+  --token               GITHUB_TOKEN env should be set                [required]
+  --repo, -r            Github repo to push draft release to          [required]
+  --next-version, --nv  The next version of the software to be release[required]
+  --commit, -c          The commit that will be tagged                [required]
+  --file                File from which to read that will be used for the
+                        release description                           [required]
+
+```
+## `release`
+Takes contents from a file and creates a release on GitHub using that contents.
 
 ```bash
 Options:

--- a/src/draftReleaseToGithub.js
+++ b/src/draftReleaseToGithub.js
@@ -1,46 +1,7 @@
 #!/usr/bin/env ./node_modules/.bin/babel-node
-import * as fs from "fs";
-
-import Octokit from "@octokit/rest";
-import { extractFromGithubUrl } from "./helpers/github";
-
-const octokit = new Octokit();
-
-async function publishDraftRelease(args, content, repoInfo) {
-  const { owner, repo } = repoInfo;
-  const { nextVersion, commit } = args;
-  try {
-    const result = await octokit.repos.createRelease({
-      owner,
-      repo,
-      tag_name: nextVersion,
-      target_commitish: commit,
-      name: nextVersion,
-      body: content,
-      draft: true,
-      prerelease: false
-    });
-    if (result.status === 201) {
-      console.log(result.data.html_url.split("/").reverse()[0]);
-    } else {
-      console.log("Draft release failed", result.status);
-    }
-    return result;
-  } catch (e) {
-    console.error(`Cannot create github release: ${e}`);
-  }
-}
-
-async function main(args, content) {
-  await publishDraftRelease(args, content, extractFromGithubUrl(args.repo));
-}
+import { init as releaseToGithub } from "./releaseToGithub";
 
 /* main*/
 export const init = args => {
-  octokit.authenticate({
-    type: "token",
-    token: args.token
-  });
-
-  main(args, fs.readFileSync(args.file, "utf8"));
+  releaseToGithub({ ...args, draft: true });
 };

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -1,6 +1,7 @@
 import yargs from "yargs";
 import { init as generateChangelog } from "./../generateChangelog";
 import { init as draftReleaseToGithub } from "../draftReleaseToGithub";
+import { init as releaseToGithub } from "../releaseToGithub";
 import { init as relaseNotesFromGithub } from "../relaseNotesFromGithub";
 
 export const setUpCli = () =>
@@ -16,6 +17,12 @@ export const setUpCli = () =>
       "Create draft release on Github",
       commandLineSetUpPublish,
       draftReleaseToGithub
+    )
+    .command(
+      "release",
+      "Create release on Github",
+      commandLineSetUpPublish,
+      releaseToGithub
     )
     .command(
       "fetch-release-notes",

--- a/src/releaseToGithub.js
+++ b/src/releaseToGithub.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+import * as fs from "fs";
+
+import Octokit from "@octokit/rest";
+import { extractFromGithubUrl } from "./helpers/github";
+
+const octokit = new Octokit();
+
+async function publishRelease(args, content, repoInfo) {
+  const { owner, repo } = repoInfo;
+  const { nextVersion, commit, draft = false } = args;
+  try {
+    const result = await octokit.repos.createRelease({
+      owner,
+      repo,
+      tag_name: nextVersion,
+      target_commitish: commit,
+      name: nextVersion,
+      body: content,
+      draft,
+      prerelease: false
+    });
+    if (result.status === 201) {
+      console.log(result.data.html_url.split("/").reverse()[0]);
+    } else {
+      console.log("Draft release failed", result.status);
+    }
+    return result;
+  } catch (e) {
+    console.error(`Cannot create github release: ${e}`);
+  }
+}
+
+async function main(args, content) {
+  await publishRelease(args, content, extractFromGithubUrl(args.repo));
+}
+
+/* main*/
+export const init = args => {
+  octokit.authenticate({
+    type: "token",
+    token: args.token
+  });
+
+  main(args, fs.readFileSync(args.file, "utf8"));
+};


### PR DESCRIPTION
Adds `practicle release` subcommand.
This has an identical interface as `draft-release` except it skips the draft stage and published the release and tag directly.