### PR TITLE
Extract out 'issues:' from pr body

### DIFF
--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env ./node_modules/.bin/babel-node
 import Octokit from "@octokit/rest";
 import semverSort from "semver-sort";
-import { extractChangeLogMessage, buildOutput } from "./helpers/changelog";
+import {
+  extractChangeLogMessage,
+  buildOutput,
+  extractIssuesFromString
+} from "./helpers/changelog";
 import { extractFromGithubUrl } from "./helpers/github";
 import { versionFilter } from "./helpers/utils";
 
@@ -68,11 +72,13 @@ async function getAllPullRequests(repoInfo) {
   return results
     .map(pr => {
       const changelogMessage = extractChangeLogMessage(pr);
+      const issues = extractIssuesFromString(pr.body);
       const { url, merge_commit_sha, number } = pr;
       if (changelogMessage) {
         return {
           sha: merge_commit_sha,
           message: changelogMessage,
+          issues,
           number,
           url
         };

--- a/src/helpers/changelog.js
+++ b/src/helpers/changelog.js
@@ -3,7 +3,7 @@ export const extractChangeLogMessage = obj => {
     return l.name === "changelog";
   });
 
-  const changelogRegex = /(^|\n|\r)changelog\:(.*)/;
+  const changelogRegex = /(^|\n|\r)changelog\:(.*)/i;
 
   const getMessage = obj => {
     const regexMatch = obj.body && obj.body.match(changelogRegex);
@@ -18,16 +18,24 @@ export const extractChangeLogMessage = obj => {
   return label.length > 0 ? getMessage(obj) : null;
 };
 
+export const extractIssuesFromString = str => {
+  const issuesRegex = /(^|\n|\r)issues\:(.*)/i;
+  const regexMatch = str && str.match(issuesRegex);
+  return regexMatch && regexMatch.length >= 2 && regexMatch[2]
+    ? `Issue(s): ${regexMatch[2].trim()}`
+    : "";
+};
+
 export const buildOutput = (logs, header, repoInfo, outputPrLinks) => {
   let out = `\n## ${header}
     `;
 
   logs.forEach(_ => {
     out += outputPrLinks
-      ? `\n- ${_.message} [\#${_.number}](https://github.com/${
+      ? `\n- ${_.message} PR: [\#${_.number}](https://github.com/${
           repoInfo.owner
-        }/${repoInfo.repo}/pull/${_.number})`
-      : `\n- ${_.message}`;
+        }/${repoInfo.repo}/pull/${_.number}) ${_.issues}`.trim()
+      : `\n- ${_.message} ${_.issues}`.trim();
   });
   console.log(out);
 };

--- a/src/helpers/changelog.js
+++ b/src/helpers/changelog.js
@@ -19,8 +19,8 @@ export const extractChangeLogMessage = obj => {
 };
 
 export const extractIssuesFromString = str => {
-  const issuesRegex = /(^|\n|\r)issues\:(.*)/i;
-  const regexMatch = str && str.match(issuesRegex);
+  const fixesRegex = /(^|\n|\r)fixes\:(.*)/i;
+  const regexMatch = str && str.match(fixesRegex);
   return regexMatch && regexMatch.length >= 2 && regexMatch[2]
     ? `Issue(s): ${regexMatch[2].trim()}`
     : "";

--- a/src/helpers/changelog.test.js
+++ b/src/helpers/changelog.test.js
@@ -63,12 +63,12 @@ describe("extractIssuesFromMessage", () => {
     expect(actual).toBeFalsy();
   });
   test("single issue", () => {
-    const message = "elliot's\nissues: emily";
+    const message = "elliot's\nfixes: emily";
     const actual = extractIssuesFromString(message);
     expect(actual).toBe("Issue(s): emily");
   });
   test("many issues", () => {
-    const message = "emily's\nissues: [num](foo), bar";
+    const message = "emily's\nfixes: [num](foo), bar";
     const actual = extractIssuesFromString(message);
     expect(actual).toBe("Issue(s): [num](foo), bar");
   });

--- a/src/helpers/changelog.test.js
+++ b/src/helpers/changelog.test.js
@@ -1,4 +1,8 @@
-import { buildOutput, extractChangeLogMessage } from "./changelog";
+import {
+  buildOutput,
+  extractChangeLogMessage,
+  extractIssuesFromString
+} from "./changelog";
 
 jest.spyOn(global.console, "log").mockImplementation(() => {});
 
@@ -52,16 +56,25 @@ describe("extractChangeLogMessage", () => {
   });
 });
 
-describe("changelog output", () => {
-  test("prints out change log", () => {
-    const message = "foobar";
-    const logs = [{ message }];
-    const header = "foobar";
-    buildOutput(logs, header, { owner: "owner", repo: "repo" }, false);
-
-    expect(getLog()).toEqual(expect.stringContaining(header));
-    expect(getLog()).toEqual(expect.stringContaining(message));
+describe("extractIssuesFromMessage", () => {
+  test("no issue", () => {
+    const message = "emily";
+    const actual = extractIssuesFromString(message);
+    expect(actual).toBeFalsy();
   });
+  test("single issue", () => {
+    const message = "elliot's\nissues: emily";
+    const actual = extractIssuesFromString(message);
+    expect(actual).toBe("Issue(s): emily");
+  });
+  test("many issues", () => {
+    const message = "emily's\nissues: [num](foo), bar";
+    const actual = extractIssuesFromString(message);
+    expect(actual).toBe("Issue(s): [num](foo), bar");
+  });
+});
+
+describe("changelog output", () => {
   test("prints out change log", () => {
     const message = "foobar";
     const logs = [{ message }];


### PR DESCRIPTION
This extracts out the `issues:` from a pr body.

Example:
``` markdown
changelog: Foo
issues: [bar](url), foo again
``` 
Returns -> `foo. Issue(s) [bar](url), foo again`