### PR TITLE
Fix issue where draft releases could not be found by tag

### DIFF
--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -9,7 +9,7 @@ const octokit = new Octokit();
 
 const defaultReleaseTagFormat = "v?(?:\\d*\\.?){3}$";
 
-async function fetchAllReleases(repoInfo, options = {}) {
+async function fetchAllTags(repoInfo) {
   const perPage = 30;
 
   async function getReleases(page) {
@@ -92,12 +92,10 @@ async function getAllPullRequests(repoInfo) {
 
 async function main(args) {
   const repoInfo = extractFromGithubUrl(args.repo);
-
   const prs = await getAllPullRequests(repoInfo);
-  const releases = await fetchAllReleases(repoInfo, {
+  const releases = await fetchAllTags(repoInfo, {
     filterString: args.releaseTagFilter || defaultReleaseTagFormat
   });
-
   const releaseTags = releases
     .map(release => release.name)
     .filter(name => versionFilter(name, args.prevVersion, args.nextVersion));

--- a/src/relaseNotesFromGithub.js
+++ b/src/relaseNotesFromGithub.js
@@ -3,22 +3,36 @@ import Octokit from "@octokit/rest";
 import { extractFromGithubUrl } from "./helpers/github";
 
 const octokit = new Octokit();
+async function fetchAllReleases(repoInfo) {
+  const perPage = 30;
 
-async function getRelease(tag, repoInfo) {
-  const { owner, repo } = repoInfo;
-  const result = await octokit.repos.getReleaseByTag({
-    owner,
-    repo,
-    tag
-  });
-
-  return result.data;
+  async function getReleases(page) {
+    const result = await octokit.repos.getReleases({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      per_page: perPage,
+      page
+    });
+    return result.data;
+  }
+  let results = [];
+  let page = 1;
+  let stillGettingReleases = true;
+  while (stillGettingReleases) {
+    const data = await getReleases(page);
+    results = [...results, ...data];
+    stillGettingReleases = data.length === perPage;
+    page += 1;
+  }
+  return results;
 }
 
 async function main(args) {
   try {
-    const release = await getRelease(args.tag, extractFromGithubUrl(args.repo));
-    if (release && release.body) {
+    const releases = await fetchAllReleases(extractFromGithubUrl(args.repo));
+    const release = releases.find(_ => _.tag_name === args.tag);
+
+    if (release && release.body !== undefined) {
       console.log(release.body);
     } else {
       throw new Error("No release body found");


### PR DESCRIPTION
If a draft is updated a new `untagged-*` id is generated in Github. To make PRacticle work in CI we now fetch and filter releases by `tag_name` so we no longer need to directly reference the release by draft id.