### PR TITLE
Configure 'generate-changlog' to fetch n number of previous tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@octokit/rest": "^15.9.5",
     "babel-runtime": "^6.26.0",
+    "semver": "^5.5.1",
     "semver-compare": "^1.0.0",
     "semver-sort": "^0.0.4",
     "yargs": "^12.0.1"

--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -104,17 +104,17 @@ async function main(args) {
     filterString: args.releaseTagFilter || defaultReleaseTagFormat
   });
   let releaseTags = Array.from(new Set(releases.map(release => release.name)));
-
   if (isValidSemVer(args.prevVersion)) {
     releaseTags = releaseTags.filter(name =>
       versionFilter(name, args.prevVersion, args.nextVersion)
     );
     releaseTags = semverSort.desc(releaseTags);
-  } else {
+  }
+  if (args.prevVersion === true) {
     releaseTags = releaseTags.filter(t => t && isValidSemVer(t));
     releaseTags = semverSort.desc(releaseTags);
     const nextTag = releaseTags.indexOf(args.nextVersion);
-    releaseTags = releaseTags.slice(nextTag, nextTag + args.prevVersion + 1);
+    releaseTags = releaseTags.slice(nextTag, nextTag + 2);
   }
 
   for (const [index, value] of releaseTags.entries()) {

--- a/src/helpers/changelog.js
+++ b/src/helpers/changelog.js
@@ -23,16 +23,18 @@ export const extractIssuesFromString = str => {
     : "";
 };
 
+const newLine = "\n";
 export const buildOutput = (logs, header, repoInfo, outputPrLinks) => {
-  let out = `\n## ${header}
-    `;
+  let out = `\n## ${header}\n`;
 
   logs.forEach(_ => {
     out += outputPrLinks
-      ? `\n- ${_.message} PR: [\#${_.number}](https://github.com/${
+      ? newLine +
+        `- ${_.message} PR: [\#${_.number}](https://github.com/${
           repoInfo.owner
-        }/${repoInfo.repo}/pull/${_.number}) ${_.issues}`.trim()
-      : `\n- ${_.message} ${_.issues}`.trim();
+        }/${repoInfo.repo}/pull/${_.number}) ${_.issues}`.trim() +
+        newLine
+      : newLine + `- ${_.message} ${_.issues}`.trim() + newLine;
   });
   console.log(out);
 };

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -4,6 +4,8 @@ import { init as draftReleaseToGithub } from "../draftReleaseToGithub";
 import { init as releaseToGithub } from "../releaseToGithub";
 import { init as relaseNotesFromGithub } from "../relaseNotesFromGithub";
 
+import { isValidSemVer } from "./utils";
+
 export const setUpCli = () =>
   yargs
     .command(
@@ -64,7 +66,8 @@ const commandLineSetUp = y =>
         alias: "pv",
         describe: `The prev version to generate the changelog from.
             - If arg is a valid Semver string (x.x.x) then the changelog will generate notes from the tag
-            - If arg is a number that will fetch n number of releases back. E.g. Given [1...9] && --next-version=10 && --prev-version=2 => 8...10
+            - If used as a flag then the changelog is generated from the previous semver tag.
+            - If ommitted then the semver major.minor version is used to generate changelogs over that range
           `
       },
       "release-tag-filter": {
@@ -76,6 +79,19 @@ const commandLineSetUp = y =>
         describe: "Override the pull requests label filter",
         type: "array",
         default: ["changelog"]
+      }
+    })
+    .check(argv => {
+      if (
+        !(
+          argv.prevVersion === undefined ||
+          argv.prevVersion === true ||
+          isValidSemVer(argv.prevVersion)
+        )
+      ) {
+        throw new Error("--prevVersion is invalid");
+      } else {
+        return true;
       }
     })
     .help()

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -62,8 +62,10 @@ const commandLineSetUp = y =>
       },
       "prev-version": {
         alias: "pv",
-        describe:
-          "The prev version tag you wish to begin the log generation from"
+        describe: `The prev version to generate the changelog from.
+            - If arg is a valid Semver string (x.x.x) then the changelog will generate notes from the tag
+            - If arg is a number that will fetch n number of releases back. E.g. Given [1...9] && --next-version=10 && --prev-version=2 => 8...10
+          `
       },
       "release-tag-filter": {
         alias: "rtf",

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,3 +1,4 @@
+import semver from "semver";
 import semverCompare from "semver-compare";
 
 export const versionFilter = (name, prevVersion, nextVersion) => {
@@ -9,3 +10,5 @@ export const versionFilter = (name, prevVersion, nextVersion) => {
           [tokenizedNextVersion[0], tokenizedNextVersion[1]].join(".")
       );
 };
+
+export const isValidSemVer = str => semver.valid(str);

--- a/src/helpers/utils.test.js
+++ b/src/helpers/utils.test.js
@@ -1,4 +1,4 @@
-import { versionFilter } from "./utils.js";
+import { versionFilter, isValidSemVer } from "./utils.js";
 
 test("versionFilter filters correctly", () => {
   const tests = [
@@ -40,4 +40,16 @@ test("versionFilter filters correctly", () => {
       versionFilter(test.tagName, test.prevVersion, test.nextVersion)
     ).toBe(test.expect)
   );
+});
+
+describe("isValidSemVer", () => {
+  test("should be invalid", () => {
+    expect(isValidSemVer("a.b.c")).toBeFalsy();
+    expect(isValidSemVer("1")).toBeFalsy();
+    expect(isValidSemVer("1.1")).toBeFalsy();
+  });
+  test("should be valid", () => {
+    expect(isValidSemVer("1.1.1")).toBeTruthy();
+    expect(isValidSemVer("v1.1.1")).toBeTruthy();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,7 +3518,7 @@ semver-sort@^0.0.4:
     semver "^5.0.3"
     semver-regex "^1.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 


### PR DESCRIPTION
Opens up `--prev-version` arg to allow users to specify how many releases they wish to go back when generating the changelog.

E.g: 
_Given Github tags=[1.0.0, 1.0.1, 1.0.2]_
```bash
practicle generate-changelog --next-version=1.0.3 --prev-version=2 ...args
```
_=> Content of [1.0.1, 1.0.2, 1.0.3]_